### PR TITLE
fix: Replace undefined enemyM.AI with enemyAI

### DIFF
--- a/gameplay.lua
+++ b/gameplay.lua
@@ -2177,8 +2177,8 @@ local function setupPeonCallbacks(peon)
         -- AI peon callbacks
         peon.resourceCheck = function()
             if not enemyAI then return false, 0, 0 end
-            local gold = enemyM.AI.gold
-            local lumber = enemyM.AI.lumber
+            local gold = enemyAI.gold
+            local lumber = enemyAI.lumber
             local canAfford = gold >= peon.buildCostGold and lumber >= peon.buildCostLumber
             return canAfford, gold, lumber
         end
@@ -2980,8 +2980,8 @@ function Gameplay.update(dt)
             canSpawn = peonReady and currentPop < maxPop
         elseif building.team == enemyTeam and enemyAI then
             -- AI handles its own population check
-            local aiPop = #enemyM.AI.peons + #enemyM.AI.footmen
-            local aiMaxPop = 4 + #enemyM.AI.farms * 4
+            local aiPop = #enemyAI.peons + #enemyAI.footmen
+            local aiMaxPop = 4 + #enemyAI.farms * 4
             canSpawn = peonReady and aiPop < aiMaxPop
         end
 


### PR DESCRIPTION
## Summary

Fixes crash bug where AI peon building and AI TownHall peon spawning would fail due to referencing non-existent `enemyM.AI` variable.

## Changes

- `enemyM.AI.gold` → `enemyAI.gold`
- `enemyM.AI.lumber` → `enemyAI.lumber`  
- `enemyM.AI.peons` → `enemyAI.peons`
- `enemyM.AI.footmen` → `enemyAI.footmen`
- `enemyM.AI.farms` → `enemyAI.farms`

## Related Issue

Fixes #23

## Bug Risk

**Low** - Simple variable name fix, no logic changes

## Testing

- [ ] Start game with AI opponent
- [ ] Verify AI can build structures (peons check resources)
- [ ] Verify AI TownHall spawns peons (population check works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)