### PR TITLE
fix: Use actual resource values in replay log

### DIFF
--- a/gameplay.lua
+++ b/gameplay.lua
@@ -2239,7 +2239,7 @@ function Gameplay.load(options)
         if options.enemies and #options.enemies > 0 then
             Game.Replay.log("CONFIG", string.format("AI: %s", options.enemies[1].personality or "blinky"))
         end
-        Game.Replay.log("CONFIG", string.format("Starting resources: %d gold, %d lumber", 2000, 400))
+        Game.Replay.log("CONFIG", string.format("Starting resources: %d gold, %d lumber", resources.gold, resources.lumber))
         -- Then log game start
         Game.Replay.log("GAME", "New game started" .. (tutorialMode and " (Tutorial)" or ""))
     end


### PR DESCRIPTION
## Summary
- Fixed replay CONFIG log showing wrong starting gold (was hardcoded 2000, actual is 1000)
- Now references `resources.gold` and `resources.lumber` variables directly

## Test plan
- [ ] Start a new game and check replay log shows "1000 gold, 400 lumber"
- [ ] Verify replay browser displays correct values

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)