### PR TITLE
feat: Add spacebar to center on selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ stable (clean history of "blessed" states)
 - Releases cut from `stable` HEAD only, versions always increase
 - Hotfixes allowed on release branches, features are not
 - **NEVER force push** - make incremental fix commits instead of amending (squash merge cleans up)
+- **PR fix comments** - after each fix commit, add a PR comment summarizing: Issue, Root cause, Fix
 
 **Branch prefixes:**
 - `feature/` - new functionality

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ stable (clean history of "blessed" states)
 - `develop` → `stable` via squash merge when stable
 - Releases cut from `stable` HEAD only, versions always increase
 - Hotfixes allowed on release branches, features are not
+- **NEVER force push** - make incremental fix commits instead of amending (squash merge cleans up)
 
 **Branch prefixes:**
 - `feature/` - new functionality

--- a/gameplay.lua
+++ b/gameplay.lua
@@ -3430,6 +3430,27 @@ function Gameplay.keypressed(key)
         end
     end
 
+    -- Spacebar centers on selection
+    if key == "space" and #selectedEntities > 0 then
+        -- Find center of selection
+        local sumX, sumY = 0, 0
+        for _, entity in ipairs(selectedEntities) do
+            -- Units use worldX/worldY, buildings use gridX/gridY
+            if entity.worldX and entity.worldY then
+                sumX = sumX + entity.worldX
+                sumY = sumY + entity.worldY
+            elseif entity.gridX and entity.gridY then
+                -- Convert grid to world coordinates (center of building)
+                local size = entity.gridSize or 1
+                sumX = sumX + (entity.gridX + size / 2 - 0.5) * map.tileSize
+                sumY = sumY + (entity.gridY + size / 2 - 0.5) * map.tileSize
+            end
+        end
+        local centerX = sumX / #selectedEntities
+        local centerY = sumY / #selectedEntities
+        map:centerOn(centerX, centerY)
+    end
+
     -- Game speed controls
     if key == "1" then
         Game.settings.gameSpeed = 0.5


### PR DESCRIPTION
## Summary
- Pressing spacebar now centers the camera on selected unit(s) or building(s)
- If multiple entities selected, centers on their average position
- No effect if nothing is selected

## Bug Fixes
1. Fixed crash when pressing spacebar with a building selected (buildings use `gridX`/`gridY`)
2. Fixed centering going to (0,0) - units use `worldX`/`worldY`, not `x`/`y`

## Test plan
- [ ] Select a unit, press spacebar - camera should center on it
- [ ] Select a building, press spacebar - camera should center on it
- [ ] Select multiple units, press spacebar - camera should center on their midpoint
- [ ] Press spacebar with nothing selected - nothing should happen
- [ ] Verify spacebar still works to dismiss victory/defeat screen

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)