### PR TITLE
perf: Add building quadtree for O(log n) collision checks

### DIFF
--- a/benchmarks/benchmark_building_collision.lua
+++ b/benchmarks/benchmark_building_collision.lua
@@ -1,0 +1,222 @@
+--[[
+    Benchmark: Building collision - Quadtree vs linear search
+
+    Compares the performance of:
+    - OLD: O(peons × buildings) checking all buildings per canMoveTo()
+    - NEW: Quadtree spatial query for nearby buildings only
+
+    Run with: love . --benchmark-building-collision
+]]
+
+local Quadtree = require("quadtree")
+
+local Benchmark = {}
+
+-- Mock building accessor functions
+local function getBuildingX(b) return b.centerX end
+local function getBuildingY(b) return b.centerY end
+
+-- Create mock buildings with random positions
+local function createMockBuildings(count, worldSize)
+    local buildings = {}
+    for i = 1, count do
+        local gridX = math.random(1, worldSize / 32 - 3)
+        local gridY = math.random(1, worldSize / 32 - 3)
+        local size = math.random(1, 3)  -- 1x1 to 3x3 buildings
+        local pixelSize = size * 32
+        local wx = (gridX - 1) * 32
+        local wy = (gridY - 1) * 32
+        table.insert(buildings, {
+            gridX = gridX,
+            gridY = gridY,
+            gridSize = size,
+            pixelSize = pixelSize,
+            centerX = wx + pixelSize / 2,
+            centerY = wy + pixelSize / 2,
+            getWorldBounds = function(self)
+                return wx, wy, wx + pixelSize, wy + pixelSize
+            end
+        })
+    end
+    return buildings
+end
+
+-- Create mock peons with random positions
+local function createMockPeons(count, worldSize)
+    local peons = {}
+    for i = 1, count do
+        table.insert(peons, {
+            worldX = math.random() * worldSize,
+            worldY = math.random() * worldSize,
+            radius = 14,
+            targetMine = nil,
+        })
+    end
+    return peons
+end
+
+-- Mock getBuildingPenetration (simplified)
+local function getBuildingPenetration(peonX, peonY, peonRadius, building)
+    local bx1, by1, bx2, by2 = building:getWorldBounds()
+    local closestX = math.max(bx1, math.min(peonX, bx2))
+    local closestY = math.max(by1, math.min(peonY, by2))
+    local dx = peonX - closestX
+    local dy = peonY - closestY
+    local dist = math.sqrt(dx * dx + dy * dy)
+    if dist < peonRadius then
+        return peonRadius - dist
+    end
+    return 0
+end
+
+-- OLD: Check ALL buildings
+local function canMoveToOld(peonX, peonY, newX, newY, peonRadius, buildings, targetMine)
+    for _, b in ipairs(buildings) do
+        if targetMine and b == targetMine then
+            goto continue
+        end
+        local currentPen = getBuildingPenetration(peonX, peonY, peonRadius, b)
+        local newPen = getBuildingPenetration(newX, newY, peonRadius, b)
+        if newPen > 0 then
+            if currentPen > 0 then
+                if newPen >= currentPen then
+                    return false
+                end
+            else
+                return false
+            end
+        end
+        ::continue::
+    end
+    return true
+end
+
+-- NEW: Use quadtree for nearby buildings
+local BUILDING_QUERY_RADIUS = 14 + 48 + 16  -- peon radius + max building half-size + margin
+local queryResults = {}
+
+local function canMoveToQuadtree(peonX, peonY, newX, newY, peonRadius, buildings, targetMine, qt)
+    -- Clear reusable table
+    for i = 1, #queryResults do queryResults[i] = nil end
+
+    -- Query nearby buildings
+    local nearbyBuildings = qt:query(newX, newY, BUILDING_QUERY_RADIUS, queryResults, getBuildingX, getBuildingY)
+
+    for _, b in ipairs(nearbyBuildings) do
+        if targetMine and b == targetMine then
+            goto continue
+        end
+        local currentPen = getBuildingPenetration(peonX, peonY, peonRadius, b)
+        local newPen = getBuildingPenetration(newX, newY, peonRadius, b)
+        if newPen > 0 then
+            if currentPen > 0 then
+                if newPen >= currentPen then
+                    return false
+                end
+            else
+                return false
+            end
+        end
+        ::continue::
+    end
+    return true
+end
+
+-- Simulate peon movement (8 direction checks per peon)
+local function simulateFrameOld(peons, buildings)
+    local directions = {
+        {1, 0}, {-1, 0}, {0, 1}, {0, -1},
+        {0.707, 0.707}, {-0.707, 0.707}, {0.707, -0.707}, {-0.707, -0.707}
+    }
+    local checks = 0
+    for _, peon in ipairs(peons) do
+        for _, dir in ipairs(directions) do
+            local newX = peon.worldX + dir[1] * 2
+            local newY = peon.worldY + dir[2] * 2
+            canMoveToOld(peon.worldX, peon.worldY, newX, newY, peon.radius, buildings, peon.targetMine)
+            checks = checks + #buildings
+        end
+    end
+    return checks
+end
+
+local function simulateFrameQuadtree(peons, buildings, qt)
+    local directions = {
+        {1, 0}, {-1, 0}, {0, 1}, {0, -1},
+        {0.707, 0.707}, {-0.707, 0.707}, {0.707, -0.707}, {-0.707, -0.707}
+    }
+    local checks = 0
+    for _, peon in ipairs(peons) do
+        for _, dir in ipairs(directions) do
+            local newX = peon.worldX + dir[1] * 2
+            local newY = peon.worldY + dir[2] * 2
+            -- Clear and query
+            for i = 1, #queryResults do queryResults[i] = nil end
+            local nearby = qt:query(newX, newY, BUILDING_QUERY_RADIUS, queryResults, getBuildingX, getBuildingY)
+            canMoveToQuadtree(peon.worldX, peon.worldY, newX, newY, peon.radius, buildings, peon.targetMine, qt)
+            checks = checks + #nearby
+        end
+    end
+    return checks
+end
+
+function Benchmark.run()
+    print("\n" .. string.rep("=", 60))
+    print("BENCHMARK: Building Collision - Quadtree vs Linear")
+    print(string.rep("=", 60))
+
+    local worldSize = 256 * 32  -- 256x256 tile map
+    local scenarios = {
+        {peons = 7, buildings = 10, name = "Early game (7 peons, 10 buildings)"},
+        {peons = 20, buildings = 30, name = "Mid game (20 peons, 30 buildings)"},
+        {peons = 40, buildings = 60, name = "Late game (40 peons, 60 buildings)"},
+        {peons = 60, buildings = 100, name = "Stress test (60 peons, 100 buildings)"},
+    }
+
+    for _, scenario in ipairs(scenarios) do
+        print(string.format("\n--- %s ---", scenario.name))
+
+        local buildings = createMockBuildings(scenario.buildings, worldSize)
+        local peons = createMockPeons(scenario.peons, worldSize)
+
+        -- Build quadtree
+        local qt = Quadtree.new(0, 0, worldSize, worldSize)
+        for _, b in ipairs(buildings) do
+            qt:insert(b, getBuildingX, getBuildingY)
+        end
+
+        local iterations = 100
+
+        -- Benchmark OLD method
+        local startOld = love.timer.getTime()
+        local oldChecks = 0
+        for i = 1, iterations do
+            oldChecks = oldChecks + simulateFrameOld(peons, buildings)
+        end
+        local timeOld = love.timer.getTime() - startOld
+
+        -- Benchmark NEW method
+        local startNew = love.timer.getTime()
+        local newChecks = 0
+        for i = 1, iterations do
+            newChecks = newChecks + simulateFrameQuadtree(peons, buildings, qt)
+        end
+        local timeNew = love.timer.getTime() - startNew
+
+        local speedup = timeOld / timeNew
+        local checksReduction = oldChecks / newChecks
+
+        print(string.format("  OLD (linear):   %.4fs (%d collision checks)", timeOld, oldChecks))
+        print(string.format("  NEW (quadtree): %.4fs (%d collision checks)", timeNew, newChecks))
+        print(string.format("  Speedup: %.2fx faster", speedup))
+        print(string.format("  Checks reduced: %.2fx fewer", checksReduction))
+    end
+
+    print("\n" .. string.rep("=", 60))
+    print("Benchmark complete!")
+    print(string.rep("=", 60) .. "\n")
+
+    love.event.quit()
+end
+
+return Benchmark

--- a/gameplay.lua
+++ b/gameplay.lua
@@ -45,9 +45,27 @@ pcall(function() M.Audio = require("audio") end)
 
 local Gameplay = {}
 
--- Persistent quadtree for spatial queries (refreshed once per frame)
+-- Persistent quadtrees for spatial queries (refreshed once per frame)
 local unitQuadtree = nil
+local buildingQuadtree = nil
 local WORLD_SIZE = 64 * 32  -- 64 tiles * 32 pixels
+
+-- Accessor functions for building quadtree (buildings use center of world bounds)
+local function getBuildingX(building)
+    if building.getWorldBounds then
+        local bx1, _, bx2, _ = building:getWorldBounds()
+        return (bx1 + bx2) / 2
+    end
+    return building.gridX and building.gridX * 32 + 16 or 0
+end
+
+local function getBuildingY(building)
+    if building.getWorldBounds then
+        local _, by1, _, by2 = building:getWorldBounds()
+        return (by1 + by2) / 2
+    end
+    return building.gridY and building.gridY * 32 + 16 or 0
+end
 
 -- Game state
 local elapsedTime = 0
@@ -315,6 +333,18 @@ local function refreshUnitQuadtree(allUnits)
     end
     for _, unit in ipairs(allUnits) do
         unitQuadtree:insert(unit, getUnitX, getUnitY)
+    end
+end
+
+-- Refresh building quadtree (buildings don't move, but can be built/destroyed)
+local function refreshBuildingQuadtree(allBuildings)
+    if not buildingQuadtree then
+        buildingQuadtree = M.Quadtree.new(0, 0, WORLD_SIZE, WORLD_SIZE)
+    else
+        buildingQuadtree:clear()
+    end
+    for _, building in ipairs(allBuildings) do
+        buildingQuadtree:insert(building, getBuildingX, getBuildingY)
     end
 end
 
@@ -2719,8 +2749,9 @@ function Gameplay.update(dt)
     local allBuildings = getAllBuildings()
     map:updateFog(allUnits, allBuildings, playerTeam)
 
-    -- Refresh quadtree once per frame for spatial queries
+    -- Refresh quadtrees once per frame for spatial queries
     refreshUnitQuadtree(allUnits)
+    refreshBuildingQuadtree(allBuildings)
 
     calculatePopulation()
     updateRequirementsState()
@@ -3027,6 +3058,7 @@ function Gameplay.update(dt)
     for _, peon in ipairs(peons) do
         -- Set quadtree reference for O(log n) unit separation lookups
         peon.unitQuadtreeRef = unitQuadtree
+        peon.buildingQuadtreeRef = buildingQuadtree
         local peonTownHall = townHall  -- Default to player's townhall
         if peon.team ~= playerTeam and enemyTownHall then
             peonTownHall = enemyTownHall

--- a/main.lua
+++ b/main.lua
@@ -425,6 +425,10 @@ function love.load(arg)
             local Benchmark = require("benchmarks.benchmark_combat")
             Benchmark.run()
             return
+        elseif a == "--benchmark-building-collision" then
+            local Benchmark = require("benchmarks.benchmark_building_collision")
+            Benchmark.run()
+            return
         end
     end
 

--- a/peon.lua
+++ b/peon.lua
@@ -262,6 +262,28 @@ function Peon:getUnitSeparation()
     return sepX, sepY
 end
 
+-- Building collision query radius: peon radius + max building half-size (3x3 tiles = 48 pixels)
+local BUILDING_QUERY_RADIUS = 14 + 48 + 16  -- Extra margin for safety
+
+-- Accessor functions for building quadtree queries
+local function getBuildingQX(b)
+    if b.getWorldBounds then
+        local bx1, _, bx2, _ = b:getWorldBounds()
+        return (bx1 + bx2) / 2
+    end
+    return b.gridX and b.gridX * 32 + 16 or 0
+end
+local function getBuildingQY(b)
+    if b.getWorldBounds then
+        local _, by1, _, by2 = b:getWorldBounds()
+        return (by1 + by2) / 2
+    end
+    return b.gridY and b.gridY * 32 + 16 or 0
+end
+
+-- Reusable table for building queries (avoids allocation)
+local buildingQueryResults = {}
+
 function Peon:canMoveTo(newX, newY, buildings)
     -- Check tree collision
     if self.map then
@@ -271,18 +293,30 @@ function Peon:canMoveTo(newX, newY, buildings)
             return false
         end
     end
-    
+
     if not buildings then return true end
-    
-    for _, b in ipairs(buildings) do
+
+    -- Use quadtree for spatial lookup if available
+    local nearbyBuildings
+    if self.buildingQuadtreeRef then
+        -- Clear reusable table
+        for i = 1, #buildingQueryResults do buildingQueryResults[i] = nil end
+        -- Query buildings near the target position
+        nearbyBuildings = self.buildingQuadtreeRef:query(newX, newY, BUILDING_QUERY_RADIUS, buildingQueryResults, getBuildingQX, getBuildingQY)
+    else
+        -- Fallback to checking all buildings
+        nearbyBuildings = buildings
+    end
+
+    for _, b in ipairs(nearbyBuildings) do
         -- Skip collision check for target mine (peon needs to walk into it)
         if self.targetMine and b == self.targetMine then
             goto continue
         end
-        
+
         local currentPen = self:getBuildingPenetration(self.worldX, self.worldY, b)
         local newPen = self:getBuildingPenetration(newX, newY, b)
-        
+
         if newPen > 0 then
             -- Would be inside building
             if currentPen > 0 then
@@ -295,10 +329,10 @@ function Peon:canMoveTo(newX, newY, buildings)
                 return false
             end
         end
-        
+
         ::continue::
     end
-    
+
     return true
 end
 

--- a/retrospectives/004-building-collision-quadtree.md
+++ b/retrospectives/004-building-collision-quadtree.md
@@ -1,0 +1,136 @@
+# Performance Optimization Report: Building Collision Quadtree
+
+## Issue
+[#42 - PERF: Peon collision checks all buildings per move](https://github.com/zinkem/domrts/issues/42)
+
+## Problem
+
+`Peon:canMoveTo()` was checking collisions against ALL buildings every time it was called. This function is called up to 8 times per peon per frame (once for each movement direction).
+
+```lua
+-- OLD: O(peons × buildings)
+function Peon:canMoveTo(newX, newY, buildings)
+    for _, b in ipairs(buildings) do  -- Loops ALL buildings!
+        local penetration = self:getBuildingPenetration(newX, newY, b)
+        if penetration > 0 then
+            return false
+        end
+    end
+    return true
+end
+```
+
+### Impact Analysis
+
+| Scenario | Peons | Buildings | Checks/Frame |
+|----------|-------|-----------|--------------|
+| Early game | 7 | 10 | 7 × 8 × 10 = **560** |
+| Mid game | 20 | 30 | 20 × 8 × 30 = **4,800** |
+| Late game | 40 | 60 | 40 × 8 × 60 = **19,200** |
+| Stress test | 60 | 100 | 60 × 8 × 100 = **48,000** |
+
+On larger maps (256×256), players build more structures and train more peons, making this bottleneck increasingly severe.
+
+## Solution
+
+Reuse the existing quadtree infrastructure (from unit separation optimization) for buildings.
+
+### Changes
+
+1. **gameplay.lua**: Added `buildingQuadtree` alongside existing `unitQuadtree`
+   - Accessor functions `getBuildingX`/`getBuildingY` use building center from `getWorldBounds()`
+   - Refreshed once per frame (buildings don't move, but can be built/destroyed)
+   - Passed to peons via `peon.buildingQuadtreeRef` property injection
+
+2. **peon.lua**: Modified `canMoveTo()` to query nearby buildings
+   - Query radius: 78 pixels (peon radius + max 3×3 building half-size + margin)
+   - Falls back to linear search if quadtree unavailable
+   - Uses reusable results table to avoid per-query allocation
+
+```lua
+-- NEW: O(peons × log(buildings))
+function Peon:canMoveTo(newX, newY, buildings)
+    local nearbyBuildings
+    if self.buildingQuadtreeRef then
+        nearbyBuildings = self.buildingQuadtreeRef:query(
+            newX, newY, BUILDING_QUERY_RADIUS,
+            queryResults, getBuildingQX, getBuildingQY
+        )
+    else
+        nearbyBuildings = buildings  -- Fallback
+    end
+
+    for _, b in ipairs(nearbyBuildings) do
+        -- Only checks 1-4 buildings instead of all 30+
+    end
+end
+```
+
+## Benchmark Results
+
+```
+============================================================
+BENCHMARK: Building Collision - Quadtree vs Linear
+============================================================
+
+--- Early game (7 peons, 10 buildings) ---
+  OLD (linear):   0.0074s (56000 collision checks)
+  NEW (quadtree): 0.0047s (0 collision checks)
+  Speedup: 1.58x faster
+
+--- Mid game (20 peons, 30 buildings) ---
+  OLD (linear):   0.0629s (480000 collision checks)
+  NEW (quadtree): 0.0222s (0 collision checks)
+  Speedup: 2.83x faster
+
+--- Late game (40 peons, 60 buildings) ---
+  OLD (linear):   0.2491s (1920000 collision checks)
+  NEW (quadtree): 0.0604s (800 collision checks)
+  Speedup: 4.13x faster
+  Checks reduced: 2400x fewer
+
+--- Stress test (60 peons, 100 buildings) ---
+  OLD (linear):   0.6094s (4800000 collision checks)
+  NEW (quadtree): 0.1103s (3200 collision checks)
+  Speedup: 5.52x faster
+  Checks reduced: 1500x fewer
+============================================================
+```
+
+### Key Observations
+
+1. **Sparse early game**: Quadtree queries often return 0 buildings because peons aren't near any structures. This is optimal - no work done when no work needed!
+
+2. **Scaling**: Speedup increases with entity count (1.58x → 5.52x). The quadtree overhead is amortized over more queries.
+
+3. **Real-world impact**: User reported 256×256 maps feeling "as smooth as other sizes" immediately after this change. The improvement was noticeable at game start, not just late game.
+
+## Why Map Size Matters
+
+Larger maps don't directly affect collision code, but they **enable** more buildings and peons:
+- More space = more structures built
+- More gold mines/trees = more workers active
+- The O(n²) problem compounds with scale
+
+## Files Changed
+
+- `gameplay.lua` - Building quadtree infrastructure
+- `peon.lua` - Spatial query in `canMoveTo()`
+- `benchmarks/benchmark_building_collision.lua` - Performance validation
+- `main.lua` - Benchmark CLI flag
+
+## Lessons Learned
+
+1. **Reuse existing infrastructure**: The quadtree was already proven for unit separation. Extending it to buildings was straightforward.
+
+2. **Property injection pattern**: Setting `peon.buildingQuadtreeRef = buildingQuadtree` avoids changing function signatures while providing access to shared state.
+
+3. **Benchmark early**: Creating benchmarks validates the optimization and provides concrete numbers for documentation.
+
+4. **Query radius matters**: Too small misses collisions. Too large defeats the purpose. Used conservative radius (peon + max building size + margin).
+
+## Run the Benchmark
+
+```bash
+/Applications/love.app/Contents/MacOS/love . --benchmark-building-collision
+```


### PR DESCRIPTION
## Summary
- Created `buildingQuadtree` for spatial partitioning of buildings
- Modified `Peon:canMoveTo()` to query nearby buildings instead of iterating all
- Reduces collision checks from O(peons × buildings) to O(peons × log(buildings))

## Performance Impact

With 20 peons and 30 buildings:
- **Before**: 20 peons × 8 directions × 30 buildings = **4,800 checks/frame**
- **After**: 20 peons × 8 directions × ~4 nearby = **~640 checks/frame** (estimated)

This is the highest-impact performance fix from the workplan.

## Implementation Details
- `buildingQuadtree` is refreshed once per frame (buildings don't move)
- Uses reusable results table to avoid per-query allocation
- Query radius of 78 pixels (peon radius + max 3x3 building half-size + margin)
- Falls back to full building list if quadtree not available

## Test plan
- [ ] Peons can still harvest gold from mines
- [ ] Peons can still chop trees
- [ ] Peons can still build structures
- [ ] Peons navigate around buildings correctly
- [ ] Peons don't walk through buildings
- [ ] Test on 128x128 map for performance improvement

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)