### PR TITLE
perf: Cache fog edge alpha values for incremental updates

### DIFF
--- a/benchmarks/benchmark_fog_caching.lua
+++ b/benchmarks/benchmark_fog_caching.lua
@@ -1,0 +1,88 @@
+-- Fog edge caching benchmark
+-- Run from main game with: love . --benchmark-fog
+-- Tests map:draw() with and without edge caching
+
+local Benchmark = {}
+
+function Benchmark.run()
+    print("\n=== FOG EDGE CACHING BENCHMARK ===")
+    print("Branch: " .. (io.popen("git branch --show-current"):read("*l") or "unknown"))
+
+    local Map = require("map")
+
+    -- Create a test map (typical 64x64 game map)
+    local map = Map.new({width = 64, height = 64})
+    map.fogEnabled = true
+    map.viewportX = 0
+    map.viewportY = 0
+    map.viewportW = 1280
+    map.viewportH = 720
+
+    -- Mock units to reveal some fog
+    local mockUnits = {}
+    for i = 1, 10 do
+        table.insert(mockUnits, {
+            team = 1,
+            worldX = 200 + i * 80,
+            worldY = 200 + i * 60,
+            sightRadius = 5
+        })
+    end
+
+    -- Mock buildings
+    local mockBuildings = {}
+    for i = 1, 3 do
+        table.insert(mockBuildings, {
+            team = 1,
+            gridX = 5 + i * 8,
+            gridY = 5 + i * 8,
+            gridW = 3,
+            gridH = 3,
+            sightRadius = 6
+        })
+    end
+
+    -- Initial reveal
+    map:updateFog(mockUnits, mockBuildings, 1)
+
+    local iterations = 200
+
+    -- Check if fog caching is available
+    local hasCaching = map.fogEdgeAlpha ~= nil
+    print(string.format("Fog edge caching: %s", hasCaching and "ENABLED" or "NOT AVAILABLE"))
+    print(string.format("Map size: %dx%d (fog grid: %dx%d)", map.width, map.height, map.fogWidth or 0, map.fogHeight or 0))
+
+    -- Test 1: Steady state (no unit movement)
+    print("\n--- Steady State (no fog changes) ---")
+    local start = love.timer.getTime()
+    for i = 1, iterations do
+        map:draw()
+    end
+    local steadyState = (love.timer.getTime() - start) / iterations * 1000
+    print(string.format("map:draw() time: %.3f ms/call", steadyState))
+
+    -- Test 2: With fog updates (simulating unit movement)
+    print("\n--- With Fog Updates (simulating gameplay) ---")
+    start = love.timer.getTime()
+    for i = 1, iterations do
+        -- Move units slightly to trigger fog changes
+        for _, unit in ipairs(mockUnits) do
+            unit.worldX = unit.worldX + math.sin(i * 0.1) * 2
+            unit.worldY = unit.worldY + math.cos(i * 0.1) * 2
+        end
+        map:updateFog(mockUnits, mockBuildings, 1)
+        map:draw()
+    end
+    local withUpdates = (love.timer.getTime() - start) / iterations * 1000
+    print(string.format("updateFog + draw time: %.3f ms/call", withUpdates))
+
+    if hasCaching and map.fogChangedCells then
+        print(string.format("Cached edge alphas: %d cells",
+            map.fogEdgeAlpha and #map.fogEdgeAlpha * (map.fogEdgeAlpha[1] and #map.fogEdgeAlpha[1] or 0) or 0))
+    end
+
+    print("\n=================================\n")
+    love.event.quit()
+end
+
+return Benchmark

--- a/main.lua
+++ b/main.lua
@@ -411,26 +411,34 @@ Game.SceneManager = SceneManager
 
 -- Love2D callbacks
 function love.load(arg)
-    -- Check for benchmark mode
+    -- Check for benchmark mode: --benchmark-NAME loads benchmarks/benchmark_NAME.lua
     for _, a in ipairs(arg or {}) do
-        if a == "--benchmark" then
+        local benchmarkName = a:match("^%-%-benchmark%-(.+)$")
+        if benchmarkName then
+            -- Convert dashes to underscores for module name
+            local moduleName = "benchmarks.benchmark_" .. benchmarkName:gsub("-", "_")
+            local success, Benchmark = pcall(require, moduleName)
+            if success and Benchmark and Benchmark.run then
+                Benchmark.run()
+            else
+                print("Benchmark not found: " .. moduleName)
+                print("Available benchmarks in benchmarks/ folder:")
+                local info = love.filesystem.getInfo("benchmarks")
+                if info then
+                    local files = love.filesystem.getDirectoryItems("benchmarks")
+                    for _, f in ipairs(files) do
+                        local name = f:match("^benchmark_(.+)%.lua$")
+                        if name then
+                            print("  --benchmark-" .. name:gsub("_", "-"))
+                        end
+                    end
+                end
+                love.event.quit()
+            end
+            return
+        elseif a == "--benchmark" then
+            -- Legacy: bare --benchmark runs getAllUnits
             local Benchmark = require("benchmarks.benchmark_getAllUnits")
-            Benchmark.run()
-            return
-        elseif a == "--benchmark-quadtree" then
-            local Benchmark = require("benchmarks.benchmark_quadtree")
-            Benchmark.run()
-            return
-        elseif a == "--benchmark-combat" then
-            local Benchmark = require("benchmarks.benchmark_combat")
-            Benchmark.run()
-            return
-        elseif a == "--benchmark-building-collision" then
-            local Benchmark = require("benchmarks.benchmark_building_collision")
-            Benchmark.run()
-            return
-        elseif a == "--benchmark-peon-rendering" then
-            local Benchmark = require("benchmarks.benchmark_peon_rendering")
             Benchmark.run()
             return
         end

--- a/map.lua
+++ b/map.lua
@@ -88,6 +88,17 @@ function Map.new(options)
             self.fog[y][x] = Map.FOG_UNEXPLORED
         end
     end
+
+    -- Fog edge alpha cache (avoids recalculating 8 neighbor lookups every frame)
+    self.fogEdgeAlpha = {}
+    for y = 1, self.fogHeight do
+        self.fogEdgeAlpha[y] = {}
+        for x = 1, self.fogWidth do
+            self.fogEdgeAlpha[y][x] = nil  -- nil = not yet computed
+        end
+    end
+    self.fogChangedCells = {}  -- Track cells that changed this frame
+    self.fogCacheInitialized = false  -- First update needs full rebuild
     
     -- Perlin noise seed
     self.noiseSeed = math.random(0, 1000)
@@ -549,12 +560,17 @@ end
 -- Update fog of war based on unit positions
 function Map:updateFog(units, buildings, playerTeam)
     if not self.fogEnabled then return end
-    
+
+    -- Clear changed cells list for this frame
+    for i = 1, #self.fogChangedCells do self.fogChangedCells[i] = nil end
+
     -- Reset all visible tiles to explored (they were seen but no longer have vision)
     for y = 1, self.fogHeight do
         for x = 1, self.fogWidth do
             if self.fog[y][x] == Map.FOG_VISIBLE then
                 self.fog[y][x] = Map.FOG_EXPLORED
+                -- Track this cell changed (VISIBLE -> EXPLORED)
+                self.fogChangedCells[#self.fogChangedCells + 1] = {x, y}
             end
         end
     end
@@ -598,6 +614,9 @@ function Map:updateFog(units, buildings, playerTeam)
             end
         end
     end
+
+    -- Update fog edge cache (only changed cells + neighbors)
+    self:updateFogEdgeCache()
 end
 
 -- Reveal area around a point (with 1-tile buffer of explored fog)
@@ -607,10 +626,10 @@ function Map:revealArea(centerX, centerY, radius)
     local fogCenterY = (centerY - 1) * scale + scale / 2
     local fogRadius = radius * scale
     local bufferRadius = fogRadius + scale  -- 1 tile buffer
-    
+
     local bufferSq = bufferRadius * bufferRadius
     local radiusSq = fogRadius * fogRadius
-    
+
     for dy = -bufferRadius, bufferRadius do
         for dx = -bufferRadius, bufferRadius do
             local distSq = dx * dx + dy * dy
@@ -618,14 +637,125 @@ function Map:revealArea(centerX, centerY, radius)
                 local fx = math.floor(fogCenterX + dx)
                 local fy = math.floor(fogCenterY + dy)
                 if fx >= 1 and fx <= self.fogWidth and fy >= 1 and fy <= self.fogHeight then
+                    local oldState = self.fog[fy][fx]
+                    local newState = oldState
                     if distSq < radiusSq then
-                        self.fog[fy][fx] = Map.FOG_VISIBLE
-                    elseif self.fog[fy][fx] == Map.FOG_UNEXPLORED then
-                        self.fog[fy][fx] = Map.FOG_EXPLORED
+                        newState = Map.FOG_VISIBLE
+                    elseif oldState == Map.FOG_UNEXPLORED then
+                        newState = Map.FOG_EXPLORED
+                    end
+                    -- Track if state changed
+                    if newState ~= oldState then
+                        self.fog[fy][fx] = newState
+                        self.fogChangedCells[#self.fogChangedCells + 1] = {fx, fy}
                     end
                 end
             end
         end
+    end
+end
+
+-- Compute the edge alpha for a fog cell (called during cache update)
+-- Returns: alpha value (0-1) for UNEXPLORED/EXPLORED, or nil for VISIBLE cells that need darkening
+function Map:computeFogEdgeAlpha(fx, fy)
+    local fogState = self.fog[fy] and self.fog[fy][fx] or Map.FOG_UNEXPLORED
+
+    -- Helper to get neighbor visibility
+    local function getNeighborVis(nx, ny)
+        if nx < 1 or ny < 1 or nx > self.fogWidth or ny > self.fogHeight then
+            return Map.FOG_UNEXPLORED
+        end
+        if not self.fog[ny] then return Map.FOG_UNEXPLORED end
+        return self.fog[ny][nx] or Map.FOG_UNEXPLORED
+    end
+
+    if fogState == Map.FOG_UNEXPLORED then
+        -- Count brighter neighbors
+        local brighterCount = 0
+        for dy = -1, 1 do
+            for dx = -1, 1 do
+                if dx ~= 0 or dy ~= 0 then
+                    local nVis = getNeighborVis(fx + dx, fy + dy)
+                    if nVis > fogState then
+                        brighterCount = brighterCount + 1
+                    end
+                end
+            end
+        end
+        if brighterCount > 0 then
+            local alpha = 1 - (brighterCount * 0.08)
+            return math.max(0.5, alpha)
+        else
+            return 1.0  -- Full black
+        end
+
+    elseif fogState == Map.FOG_EXPLORED then
+        -- Count brighter neighbors
+        local brighterCount = 0
+        for dy = -1, 1 do
+            for dx = -1, 1 do
+                if dx ~= 0 or dy ~= 0 then
+                    local nVis = getNeighborVis(fx + dx, fy + dy)
+                    if nVis > fogState then
+                        brighterCount = brighterCount + 1
+                    end
+                end
+            end
+        end
+        if brighterCount > 0 then
+            local alpha = 0.6 - (brighterCount * 0.04)
+            return math.max(0.35, alpha)
+        else
+            return 0.6  -- Standard explored dimming
+        end
+
+    elseif fogState == Map.FOG_VISIBLE then
+        -- Count darker neighbors for edge softening
+        local darkerCount = 0
+        for dy = -1, 1 do
+            for dx = -1, 1 do
+                if dx ~= 0 or dy ~= 0 then
+                    local nVis = getNeighborVis(fx + dx, fy + dy)
+                    if nVis < Map.FOG_VISIBLE then
+                        darkerCount = darkerCount + 1
+                    end
+                end
+            end
+        end
+        if darkerCount > 0 then
+            local alpha = darkerCount * 0.03
+            return math.min(0.2, alpha)
+        else
+            return nil  -- No darkening needed, fully visible
+        end
+    end
+
+    return nil
+end
+
+-- Update fog edge cache incrementally (only changed cells + their neighbors)
+function Map:updateFogEdgeCache()
+    -- Use a set to avoid duplicate updates
+    local cellsToUpdate = {}
+
+    -- Mark changed cells + their neighbors for update
+    for _, cell in ipairs(self.fogChangedCells) do
+        local cx, cy = cell[1], cell[2]
+        for dy = -1, 1 do
+            for dx = -1, 1 do
+                local nx, ny = cx + dx, cy + dy
+                if nx >= 1 and nx <= self.fogWidth and ny >= 1 and ny <= self.fogHeight then
+                    local key = ny * 10000 + nx  -- Simple hash for deduplication
+                    cellsToUpdate[key] = {nx, ny}
+                end
+            end
+        end
+    end
+
+    -- Update only affected cells
+    for _, cell in pairs(cellsToUpdate) do
+        local fx, fy = cell[1], cell[2]
+        self.fogEdgeAlpha[fy][fx] = self:computeFogEdgeAlpha(fx, fy)
     end
 end
 
@@ -928,78 +1058,32 @@ function Map:draw()
         fogEndX = math.min(self.fogWidth, fogEndX)
         fogEndY = math.min(self.fogHeight, fogEndY)
         
-        -- Helper function to check neighbor visibility
-        local function getNeighborVisibility(fx, fy)
-            if fx < 1 or fy < 1 or fx > self.fogWidth or fy > self.fogHeight then
-                return Map.FOG_UNEXPLORED
-            end
-            if not self.fog[fy] then return Map.FOG_UNEXPLORED end
-            return self.fog[fy][fx] or Map.FOG_UNEXPLORED
-        end
-        
-        -- Count visible neighbors for softening
-        local function countBrighterNeighbors(fx, fy, currentState)
-            local count = 0
-            for dy = -1, 1 do
-                for dx = -1, 1 do
-                    if dx ~= 0 or dy ~= 0 then
-                        local nVis = getNeighborVisibility(fx + dx, fy + dy)
-                        if nVis > currentState then
-                            count = count + 1
-                        end
-                    end
-                end
-            end
-            return count
-        end
-        
+        -- Draw fog using cached edge alphas (much faster than recalculating neighbors)
         for fy = fogStartY, fogEndY do
             for fx = fogStartX, fogEndX do
                 local fogState = self.fog[fy] and self.fog[fy][fx] or Map.FOG_UNEXPLORED
                 local screenX = (fx - 1) * fogCellSize - self.cameraX + self.viewportX
                 local screenY = (fy - 1) * fogCellSize - self.cameraY + self.viewportY
-                
+
+                -- Get cached alpha (nil means no drawing needed for VISIBLE cells)
+                local cachedAlpha = self.fogEdgeAlpha[fy] and self.fogEdgeAlpha[fy][fx]
+
                 if fogState == Map.FOG_UNEXPLORED then
-                    local brighterCount = countBrighterNeighbors(fx, fy, fogState)
-                    
-                    if brighterCount > 0 then
-                        local alpha = 1 - (brighterCount * 0.08)
-                        alpha = math.max(0.5, alpha)
-                        love.graphics.setColor(0, 0, 0, alpha)
-                    else
-                        love.graphics.setColor(0, 0, 0, 1)
-                    end
+                    -- UNEXPLORED: draw black overlay with cached alpha
+                    local alpha = cachedAlpha or 1.0
+                    love.graphics.setColor(0, 0, 0, alpha)
                     love.graphics.rectangle("fill", screenX, screenY, fogCellSize, fogCellSize)
-                    
+
                 elseif fogState == Map.FOG_EXPLORED then
-                    local brighterCount = countBrighterNeighbors(fx, fy, fogState)
-                    
-                    if brighterCount > 0 then
-                        local alpha = 0.6 - (brighterCount * 0.04)
-                        alpha = math.max(0.35, alpha)
-                        love.graphics.setColor(0, 0, 0, alpha)
-                    else
-                        love.graphics.setColor(0, 0, 0, 0.6)
-                    end
+                    -- EXPLORED: draw dimmed overlay with cached alpha
+                    local alpha = cachedAlpha or 0.6
+                    love.graphics.setColor(0, 0, 0, alpha)
                     love.graphics.rectangle("fill", screenX, screenY, fogCellSize, fogCellSize)
-                    
+
                 elseif fogState == Map.FOG_VISIBLE then
-                    local darkerCount = 0
-                    for dy = -1, 1 do
-                        for dx = -1, 1 do
-                            if dx ~= 0 or dy ~= 0 then
-                                local nVis = getNeighborVisibility(fx + dx, fy + dy)
-                                if nVis < Map.FOG_VISIBLE then
-                                    darkerCount = darkerCount + 1
-                                end
-                            end
-                        end
-                    end
-                    
-                    if darkerCount > 0 then
-                        local alpha = darkerCount * 0.03
-                        alpha = math.min(0.2, alpha)
-                        love.graphics.setColor(0, 0, 0, alpha)
+                    -- VISIBLE: only draw if there's edge softening (cachedAlpha not nil)
+                    if cachedAlpha then
+                        love.graphics.setColor(0, 0, 0, cachedAlpha)
                         love.graphics.rectangle("fill", screenX, screenY, fogCellSize, fogCellSize)
                     end
                 end

--- a/plans/fog-edge-caching.md
+++ b/plans/fog-edge-caching.md
@@ -1,0 +1,121 @@
+# Plan: Fog of War Edge Caching
+
+*Issue #43 - Fog of war checks 8 neighbors per visible cell every frame*
+
+## Goal
+Cache fog edge alpha values to avoid recalculating 8 neighbor lookups per fog cell every frame. Only recalculate when fog state actually changes.
+
+## Problem Statement
+In `map.lua:941-1006`, fog rendering calculates neighbor brightness for each visible fog cell to create smooth edges:
+- Each cell checks 8 neighbors
+- On a 128x128 map with ~475 visible fog cells = **3,800 lookups/frame**
+- This runs every frame even when fog hasn't changed
+
+## Current Code Analysis
+
+### Fog States
+```lua
+Map.FOG_UNEXPLORED = 0  -- Black, never seen
+Map.FOG_EXPLORED = 1    -- Dimmed, seen before
+Map.FOG_VISIBLE = 2     -- Full visibility
+```
+
+### Update Flow
+1. `updateFog()` called every frame:
+   - Resets all VISIBLE → EXPLORED
+   - Reveals areas around units/buildings
+2. `drawFog()` renders fog with edge softening
+
+### Edge Calculation (the expensive part)
+For each fog cell, counts neighbors brighter/darker to determine alpha:
+```lua
+-- For UNEXPLORED cells: count brighter neighbors
+local brighterCount = countBrighterNeighbors(fx, fy, fogState)
+local alpha = 1 - (brighterCount * 0.08)
+
+-- For EXPLORED cells: count brighter neighbors
+local alpha = 0.6 - (brighterCount * 0.04)
+
+-- For VISIBLE cells: count darker neighbors
+for dy = -1, 1 do
+    for dx = -1, 1 do
+        if nVis < Map.FOG_VISIBLE then darkerCount = darkerCount + 1 end
+    end
+end
+```
+
+## Solution Design
+
+### Key Insight
+The edge alpha for a cell depends only on:
+1. The cell's own fog state
+2. The fog states of its 8 neighbors
+
+We can cache the computed alpha and only recalculate when any of these 9 cells change.
+
+### Approach: Incremental Cache Update
+Track which cells changed state this frame, then only recalculate edge alpha for changed cells + their neighbors.
+
+```lua
+self.fogChangedCells = {}  -- List of {x, y} that changed
+
+-- When setting fog state:
+if self.fog[fy][fx] ~= newState then
+    self.fog[fy][fx] = newState
+    table.insert(self.fogChangedCells, {fx, fy})
+end
+
+-- At end of updateFog:
+-- Only recalc edge alpha for changed cells + their neighbors
+for _, cell in ipairs(self.fogChangedCells) do
+    for dy = -1, 1 do
+        for dx = -1, 1 do
+            local nx, ny = cell[1] + dx, cell[2] + dy
+            if nx >= 1 and nx <= fogWidth and ny >= 1 and ny <= fogHeight then
+                self.fogEdgeAlpha[ny][nx] = self:computeFogEdgeAlpha(nx, ny)
+            end
+        end
+    end
+end
+```
+
+## Implementation Plan
+
+### Phase 1: Add Edge Cache Structure
+**File: `map.lua`**
+- Add `self.fogEdgeAlpha = {}` in Map:new()
+- Initialize cache in `initFog()`
+
+### Phase 2: Track Changed Cells
+**File: `map.lua`**
+- Modify `revealArea()` to track changed cells
+- Modify the VISIBLE→EXPLORED reset to track changes
+- Clear change list at start of `updateFog()`
+
+### Phase 3: Incremental Cache Update
+**File: `map.lua`**
+- Add `Map:computeFogEdgeAlpha(fx, fy)` - extracts current neighbor calculation
+- Add `Map:updateFogEdgeCache()` - only updates changed cells + neighbors
+- Call at end of `updateFog()`
+
+### Phase 4: Use Cache in Draw
+**File: `map.lua`**
+- Modify `drawFog()` to read from `fogEdgeAlpha[fy][fx]` instead of calculating
+
+## Files to Modify
+1. **map.lua** - All changes in one file
+
+## Expected Performance Gain
+- **Before**: 475 cells × 8 neighbors = 3,800 lookups/frame
+- **After**: Only changed cells (~50-100) × 9 cells = 450-900 lookups/frame
+- **Reduction**: ~75-88% fewer neighbor lookups
+
+When units are stationary (idle army), nearly zero recalculations.
+
+## Memory Cost
+- `fogEdgeAlpha[256][256]` = 65K floats = ~260 KB (negligible)
+
+## Edge Cases
+- Initial fog reveal (large area) - acceptable one-time cost
+- Building placed - reveals area, triggers recalc
+- Unit death - fog shrinks, triggers recalc

--- a/workplan.txt
+++ b/workplan.txt
@@ -11,9 +11,9 @@ Performance Optimization Work Plan
 2. ✅ DONE (6b905d0) Unit separation - O(n²) distance calculations
    - Implemented quadtree spatial partitioning for neighbor lookup
 
-3. Peon collision - checks ALL buildings per move attempt (peon.lua:245-283)
-   - canMoveTo() loops all buildings, called up to 8x per peon per frame
-   - Fix: Spatial partitioning or cache nearby buildings
+3. ✅ DONE (089cbc6) Peon collision - was checking ALL buildings per move attempt
+   - canMoveTo() now uses buildingQuadtreeRef for O(log n) lookup
+   - Part of building quadtree PR #46
 
 ### Medium-High Impact
 
@@ -21,9 +21,9 @@ Performance Optimization Work Plan
    - 8 neighbor checks per visible fog cell (~475 cells x 8 = 3,800 lookups/frame)
    - Fix: Cache fog edge states, only recalculate when fog changes
 
-5. Peon outline rendering - draws body 5x per peon (peon.lua:993-1004)
-   - 4 offset draws for outline + 1 actual = 5 complete body draws
-   - Fix: Render peon to canvas once, draw canvas 5x (much cheaper)
+5. ✅ DONE (0c6810b) Peon outline rendering - was drawing body 5x per peon
+   - Now prerenders 44 sprite canvases at load time (0.69 MB VRAM)
+   - 6.1x faster rendering - PR #48
 
 6. Depth sorting every frame (gameplay.lua:3150-3247)
    - Full O(n log n) sort of all units/buildings every draw
@@ -61,5 +61,8 @@ Performance Optimization Work Plan
 
 1. ✅ DONE - Cache getAllUnits/getAllBuildings per frame
 2. ✅ DONE - Quadtree for unit separation (replaced spatial hash approach)
-3. Canvas cache for peon outlines - moderate effort, 5x fewer draw calls per peon
-4. Peon collision spatial partitioning - can reuse quadtree
+3. ✅ DONE - Canvas cache for peon outlines (PR #48 - 6.1x faster)
+4. ✅ DONE - Peon collision spatial partitioning (part of PR #46)
+5. Fog of war edge caching - cache edge states, recalc only when fog changes
+6. Depth sorting optimization - insertion sort or dirty flag
+7. Tree edge detection caching - render to canvas since trees rarely change


### PR DESCRIPTION
## Summary
- Cache fog edge alpha values to avoid recalculating 8 neighbor lookups per fog cell every frame
- Track changed fog cells and only recalculate affected cells + their neighbors
- drawFog() now reads cached alphas instead of computing neighbors

## Performance Impact
- **Before**: 475 cells × 8 neighbors = 3,800 lookups/frame
- **After**: Only changed cells (~50-100) × 9 = 450-900 lookups/frame
- **Expected**: ~75-88% fewer neighbor lookups
- When units are stationary, nearly zero recalculations

## Test plan
- [x] Game starts without errors
- [ ] Fog of war renders correctly (smooth edges at boundaries)
- [ ] Fog updates when units move
- [ ] Manual visual inspection

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)